### PR TITLE
allow different types for parameters

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -170,7 +170,7 @@ variable "overrides" {
 }
 
 variable "parameters" {
-  type        = map(any)
+  type        = any
   default     = null
   description = "(Optional) A mapping of any Parameters for this Policy."
 }


### PR DESCRIPTION
## Description

Having issue when trying to deploy a policy with parameters of different types:
````
 │ Error: Invalid value for input variable
  │ 
  │   on .terraform/modules/azure_policy/policy.tf line 62, in module "assign_policy_at_subscription":
  │   62:   parameters         = var.policy_assignment.parameters
  │ 
  │ The given value is not suitable for module.azure_policy["Allowed registry
  │ models"].module.assign_policy_at_subscription.var.parameters declared at
  │ .terraform/modules/azure_policy.assign_policy_at_subscription/variables.tf:171,1-22:
  │ all map elements must have the same type.
````
Fixes #81
-->

## Type of Change


- [x ] Azure Verified Module updates:
    - [x ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.


# Checklist

- [x ] I'm sure there are no other open Pull Requests for the same update/change
- [ x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
